### PR TITLE
infinite scroll search results and limit related buildings

### DIFF
--- a/app/components/Cards.jsx
+++ b/app/components/Cards.jsx
@@ -1,22 +1,44 @@
 import React from 'react'
 import Card from './Card'
+import _ from 'lodash'
 
 export default class Cards extends React.Component {
   constructor(props) {
     super(props)
+
+    this.state = {
+      cardsLoaded: 12
+    }
+
+    this.addCards = this.addCards.bind(this)
+  }
+
+  componentWillMount() {
+    const self = this;
+    this.handleScroll = _.debounce(function(event) {
+      const windowHeight = window.innerHeight;
+      const scrollDistance = document.querySelector('.cards').scrollTop;
+      if (windowHeight - scrollDistance < 1000) self.addCards()
+    }, 100)
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    if (_.isEqual(nextProps.buildings, this.props.buildings)) {
+    if (_.isEqual(nextProps.buildings, this.props.buildings) &&
+        this.state.cardsLoaded === nextState.cardsLoaded) {
       return false;
     }
     return true;
   }
 
+  addCards() {
+    const cardsLoaded = this.state.cardsLoaded;
+    this.setState({cardsLoaded: cardsLoaded + 12})
+  }
+
   render() {
     return (
-      <div className='cards'>
-        {this.props.buildings.map((building, i) => {
+      <div className='cards' onScroll={this.handleScroll}>
+        {_.take(this.props.buildings, this.state.cardsLoaded).map((building, i) => {
           return <Card key={i} building={building} />
         })}
       </div>

--- a/app/components/Map.jsx
+++ b/app/components/Map.jsx
@@ -51,6 +51,9 @@ const MapComponent = withGoogleMap(props => (
     defaultZoom={props.mapConfig.zoom}
     center={props.mapConfig.location}
     defaultCenter={props.mapConfig.location}
+    defaultOptions={{
+      scrollwheel: false,
+    }}
   >
     {props.buildings.map((building, idx) => (
       <Marker

--- a/app/components/building/Related.jsx
+++ b/app/components/building/Related.jsx
@@ -29,7 +29,7 @@ export default class Related extends React.Component {
       <div className='related'>
         <div className='related-buildings'>
           {this.state.buildings.length > 0 ?
-            this.state.buildings.map((building, i) => {
+            _.take(this.state.buildings, 8).map((building, i) => {
               return (<Card building={building} key={i} label={'address'} />)
             })
             : null


### PR DESCRIPTION
This PR greatly reduces page load size by implementing infinite scrolling on the search page and by limiting the number of similar buildings to be rendered on building#show routes.

Previous page sizes: ~15MB; current: ~1.5

closes #120 