### PR TITLE
Building markers ie

### DIFF
--- a/app/components/map/Marker.jsx
+++ b/app/components/map/Marker.jsx
@@ -10,16 +10,22 @@ export default class MapMarker extends React.Component {
       hovered: false
     }
 
+    this.isIe = this.isIe.bind(this)
     this.handleMouseOver = this.handleMouseOver.bind(this)
     this.handleMouseOut = this.handleMouseOut.bind(this)
   }
 
+  isIe() {
+    const userAgent = window.navigator.userAgent;
+    return userAgent.includes('MSIE') || userAgent.includes('.NET');
+  }
+
   handleMouseOver() {
-    this.setState({hovered: true})
+    if (!this.isIe()) this.setState({hovered: true})
   }
 
   handleMouseOut() {
-    this.setState({hovered: false})
+    if (!this.isIe()) this.setState({hovered: false})
   }
 
   render() {


### PR DESCRIPTION
IE calls the mouseout event constantly when the mouse hovers on a building marker. One common workaround is evidently to use the onmouseleave event instead, which should work properly in IE. However, the Google Maps API does not expose this event, nor does the map library we're calling that wraps Google maps, so we can't support the onmouseleave event.

This PR resolves this visual issue by disabling the building marker card on ie browsers.

closes #269 