### PR TITLE
Lightbox caption on mobile

### DIFF
--- a/app/styles/building-lightbox-circle-buttons.css
+++ b/app/styles/building-lightbox-circle-buttons.css
@@ -25,7 +25,7 @@
   background: #EDA138;
 }
 
-@media(max-width: 600px) {
+@media(max-width: 900px) {
   .building-lightbox-circle-buttons {
     display: none;
   }

--- a/app/styles/building-lightbox.css
+++ b/app/styles/building-lightbox.css
@@ -29,7 +29,7 @@
 }
 
 /**
-* Body contenet
+* Body content
 **/
 
 .building-lightbox .modal .body {
@@ -95,18 +95,17 @@
   background: inherit;
 }
 
-@media(max-width: 600px) {
+@media(max-width: 900px) {
   .building-lightbox .lightbox-caption {
     position: absolute;
-    bottom: 0px;
+    bottom: -55px;
     color: #fff;
     padding: 10px;
     text-align: center;
     box-sizing: border-box;
     width: 100%;
     background: inherit;
-    min-height: 60px;
-    max-height: 80px;
+    height: 55px;
     overflow: scroll;
     left: 0;
     font-size: 0.9em;


### PR DESCRIPTION
Resolves #265.

On mobile, where scrolling in the captions is an option, the height of the caption box is now kept constant and aligns with the bottom of the image box so no overlap/cropping occurs.