### PR TITLE
Style RichTextArea as tablecell and accept height prop

### DIFF
--- a/app/components/admin/form/Overview.jsx
+++ b/app/components/admin/form/Overview.jsx
@@ -112,7 +112,8 @@ export default class Overview extends React.Component {
           width={'full-width'}
           label={'Overview Description'}
           field={'overview_description'}
-          placeholder={'A pithy description of what a visitor to the building sees or should look for.'}
+          height={250}
+          placeholder={'A pithy description of what a visitor to the building sees or should look for.  Summarize basic physical features, say something about its current use, and suggest some narrative or significance of the building.  Tone is engaging and conversational.'}
         />
 
         <TextInput {...this.props}

--- a/app/components/admin/form/form-elements/RichTextArea.jsx
+++ b/app/components/admin/form/form-elements/RichTextArea.jsx
@@ -17,15 +17,15 @@ export default class RichTextArea extends React.Component {
   }
 
   updateField(value) {
-    console.log(value)
     this.props.updateField(this.props.field, value)
   }
 
   render() {
     return (
-      <div className={this.getClass()} style={{ display: 'block' }}>
+      <div className={this.getClass()}>
         <div className='label'>{this.props.label}</div>
         <ReactQuill
+          style={{ height: this.props.height }}
           onChange={this.updateField}
           placeholder={this.props.placeholder || ''}
           value={this.props.building[this.props.field] || ''}

--- a/app/styles/form-elements.css
+++ b/app/styles/form-elements.css
@@ -11,7 +11,8 @@
 
 .form .label,
 .form select,
-.form input {
+.form input,
+.form .quill {
   display: table-cell;
   height: 30px;
   margin: 6px 0;
@@ -60,12 +61,17 @@
   height: auto;
 }
 
+.form .quill {
+  padding: 6px 0;
+}
+
 /**
 * Full width
 **/
 
 .form .full-width {
   display: table;
+  table-layout: fixed;
   width: 100%;
 }
 
@@ -75,6 +81,7 @@
 
 .form .half-width {
   display: table;
+  table-layout: fixed;
   width: 50%;
 }
 
@@ -153,12 +160,4 @@
 
 .form .multiselect .select-checkboxes input[type=checkbox] {
   margin-right: 8px;
-}
-
-/**
-* Rich textarea
-**/
-
-.form .rich-text-area .label {
-  width: 100%;
 }


### PR DESCRIPTION
Resolves #304 

Changes rich text area to `table-cell` so that it displays like other `full-width` form elements. Also add `height` prop to replace `rows` prop functionality used by `TextArea`. Also adds `table-layout: fixed` to `full-width` class to prevent quill editor from dynamically resizing width and exceeding div boundaries.